### PR TITLE
Added value list handling in inout-intern outputs.

### DIFF
--- a/symbol.lisp
+++ b/symbol.lisp
@@ -36,11 +36,12 @@
 ;; outval: immediate output of the body
 (defmacro inout-intern ((bgnval midval inpkg &key (callpkg nil)) &body body)
   `(let* ((,midval (intern-symbols-recursive ,bgnval ,inpkg))
-          (outval (progn ,@body)))
-     (cond
-       (,callpkg (intern-symbols-recursive outval ,callpkg))
-       (*intern-caller-pkg* (intern-symbols-recursive outval *intern-caller-pkg*))
-       (t outval))))
+          (outval (multiple-value-list (progn ,@body))))
+     (values-list
+       (cond
+         (,callpkg (intern-symbols-recursive outval ,callpkg))
+         (*intern-caller-pkg* (intern-symbols-recursive outval *intern-caller-pkg*))
+         (t outval)))))
 ;; Same as inout-intern macro but only performs the pre- interning portion.
 ;; Interns the incoming symbols and stores it in midval before evaluating
 ;; the body.


### PR DESCRIPTION
Before using inout-intern with a value list output would lose the values that are not the main return value (the first value). Now all of them are returned and all are interned.